### PR TITLE
Refactor/improve connection loading

### DIFF
--- a/src/components/domain/connection-dialog/index.tsx
+++ b/src/components/domain/connection-dialog/index.tsx
@@ -1,7 +1,8 @@
 import classNames from "classnames";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
-import { useRoom } from "../../../contexts/room-context";
+import { useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import { MainRoomEvents, useRoom } from "../../../contexts/room-context";
 import { storageManager } from "../../../utils/storage-manager";
 import Dialog from "../../ui/dialog";
 import { ConnectingMessage } from "./connecting-message";
@@ -16,29 +17,37 @@ interface ConnectionDialogProps {
 
 function ConnectionDialog({ onRequestClose, isOpen }: ConnectionDialogProps) {
   const router = useRouter();
-  const { connectOnRoom, disconnectOnRoom, peerId } = useRoom();
+  const { connectOnRoom, disconnectOnRoom, peerId, room } = useRoom();
+
+  const [isConnectingIntoRoom, setIsConnectingIntoRoom] = useState(true);
 
   const [isFillPeopleName, setIsFillPeopleName] = useState(
     () => !!storageManager.getItem("@planning:people-name")
   );
 
+  const isInitialInteraction = useRef(true);
+  const connectionDebounceTimer = useRef(0);
+
   async function onCancelRoomConnection() {
+    await router.replace("/");
     await disconnectOnRoom();
     onRequestClose();
-    router.replace("/");
   }
 
   async function handleConnectOnRoom() {
     const roomId = router.query.room_id as string;
     const peopleName = storageManager.getItem("@planning:people-name");
 
-    await connectOnRoom(roomId, peopleName);
-
-    onRequestClose();
+    try {
+      await connectOnRoom(roomId, peopleName);
+    } catch {
+      toast.error("Não foi possível se conectar a essa sala");
+      router.replace("/");
+    }
   }
 
   function renderContent() {
-    if (isFillPeopleName) {
+    if (isFillPeopleName || isConnectingIntoRoom) {
       return (
         <ConnectingMessage onCancelRoomConnection={onCancelRoomConnection} />
       );
@@ -59,6 +68,41 @@ function ConnectionDialog({ onRequestClose, isOpen }: ConnectionDialogProps) {
 
     handleConnectOnRoom();
   }, [isFillPeopleName, peerId]);
+
+  useEffect(() => {
+    if (isInitialInteraction.current) {
+      isInitialInteraction.current = false;
+      return;
+    }
+
+    if (!isConnectingIntoRoom) {
+      onRequestClose();
+    }
+  }, [isConnectingIntoRoom]);
+
+  useEffect(() => {
+    if (!room?.subscription) return;
+
+    function debounceConnectionLoad() {
+      clearTimeout(connectionDebounceTimer.current);
+
+      if (connectionDebounceTimer.current > -1) {
+        window.setTimeout(() => {
+          setIsConnectingIntoRoom(false);
+          connectionDebounceTimer.current = -1;
+        }, 750);
+      }
+    }
+
+    room.subscription.bind(MainRoomEvents.PEOPLE_ENTER, debounceConnectionLoad);
+
+    return () => {
+      room.subscription.unbind(
+        MainRoomEvents.PEOPLE_ENTER,
+        debounceConnectionLoad
+      );
+    };
+  }, [room?.subscription]);
 
   return (
     <Dialog

--- a/src/contexts/room-context.tsx
+++ b/src/contexts/room-context.tsx
@@ -21,6 +21,13 @@ export interface People {
   points?: number;
 }
 
+export enum MainRoomEvents {
+  PEOPLE_ENTER = "PEOPLE_ENTER",
+  PEOPLE_LEAVE = "PEOPLE_LEAVE",
+  SELECT_POINT = "SELECT_POINT",
+  SHOW_POINTS = "SHOW_POINTS",
+}
+
 interface RoomInfo {
   name: string;
   id: string;
@@ -147,7 +154,7 @@ export function RoomContextProvider({ children }: RoomContextProviderProps) {
       });
     });
 
-    channel.bind("PEOPLE_ENTER", async (people: People) => {
+    channel.bind(MainRoomEvents.PEOPLE_ENTER, async (people: People) => {
       updateRoom({
         type: "add_people",
         payload: {
@@ -164,7 +171,7 @@ export function RoomContextProvider({ children }: RoomContextProviderProps) {
       }
     });
 
-    channel.bind("PEOPLE_LEAVE", (people: People) => {
+    channel.bind(MainRoomEvents.PEOPLE_LEAVE, (people: People) => {
       updateRoom({
         type: "remove_people",
         payload: {
@@ -173,7 +180,7 @@ export function RoomContextProvider({ children }: RoomContextProviderProps) {
       });
     });
 
-    channel.bind("SELECT_POINT", (people: People) => {
+    channel.bind(MainRoomEvents.SELECT_POINT, (people: People) => {
       if (senderPeople.id !== people.id) {
         updateRoom({
           type: "update_people",
@@ -187,7 +194,7 @@ export function RoomContextProvider({ children }: RoomContextProviderProps) {
       }
     });
 
-    channel.bind("SHOW_POINTS", ({ show }) => {
+    channel.bind(MainRoomEvents.SHOW_POINTS, ({ show }) => {
       if (show) {
         setShowPointsCountdown(3);
       }

--- a/src/contexts/room-context.tsx
+++ b/src/contexts/room-context.tsx
@@ -31,6 +31,7 @@ export enum MainRoomEvents {
 interface RoomInfo {
   name: string;
   id: string;
+  subscription: Channel;
   showPoints?: boolean;
   peoples?: People[];
 }
@@ -45,6 +46,7 @@ interface RoomReducerAction {
   payload?: {
     id?: string;
     name?: string;
+    subscription?: Channel;
     showPoints?: boolean;
     people?: Partial<People>;
   };
@@ -70,6 +72,7 @@ function roomReducer(state: RoomInfo, action: RoomReducerAction) {
       return {
         id: action.payload.id,
         name: action.payload.name,
+        subscription: action.payload.subscription,
         peoples: [],
       };
     case "add_people":
@@ -235,6 +238,7 @@ export function RoomContextProvider({ children }: RoomContextProviderProps) {
     _unsubscribeAll();
 
     const subscription = peer.subscribe(roomId);
+
     const { data } = await api.get("/get-room-name", {
       params: {
         room_id: roomId,
@@ -253,6 +257,7 @@ export function RoomContextProvider({ children }: RoomContextProviderProps) {
       payload: {
         id: roomId,
         name: data.name,
+        subscription,
       },
     });
 

--- a/src/contexts/room-context.tsx
+++ b/src/contexts/room-context.tsx
@@ -136,6 +136,8 @@ export function RoomContextProvider({ children }: RoomContextProviderProps) {
   }, [showPointsCountdown]);
 
   function _prepareRoomConnection(channel: Channel, senderPeople: People) {
+    channel.bind_global((event) => console.log("[pusher events]", event));
+
     channel.bind(`LOAD_PEOPLE:${peer.sessionID}`, (people: People) => {
       updateRoom({
         type: "add_people",


### PR DESCRIPTION
## Motivação
Necessidade de melhorar a experiência de carregamento de uma sala. Atualmente, quando se entra em uma sala, após o diálogo de carregamento sumir, as pessoas da sala ainda não foram devidamente carregadas.

## Solução
Criação de um debounce que aguarda até todas as pessoas iniciais serem carregadas antes de terminar o carregamento da sala.

### Antes

https://user-images.githubusercontent.com/37812781/187011345-db5510e7-55d1-4ca0-8716-06888a84a698.mp4

### Depois

https://user-images.githubusercontent.com/37812781/187011357-19fc3262-33a8-4757-b81d-d20e3b883958.mp4


