### PR TITLE
fix: adjust loading room dialog condition

### DIFF
--- a/src/components/domain/connection-dialog/index.tsx
+++ b/src/components/domain/connection-dialog/index.tsx
@@ -47,17 +47,17 @@ function ConnectionDialog({ onRequestClose, isOpen }: ConnectionDialogProps) {
   }
 
   function renderContent() {
-    if (isFillPeopleName || isConnectingIntoRoom) {
+    if (!isFillPeopleName) {
       return (
-        <ConnectingMessage onCancelRoomConnection={onCancelRoomConnection} />
+        <PeopleForm
+          onCancelRoomConnection={onCancelRoomConnection}
+          setIsFillPeopleName={setIsFillPeopleName}
+        />
       );
     }
 
     return (
-      <PeopleForm
-        onCancelRoomConnection={onCancelRoomConnection}
-        setIsFillPeopleName={setIsFillPeopleName}
-      />
+      <ConnectingMessage onCancelRoomConnection={onCancelRoomConnection} />
     );
   }
 


### PR DESCRIPTION
## Motivação
Atualmente o comportamento do modal de carregamento está incorreto. Na tentativa de entrar diretamente em uma sala, sem ter previamente preenchido o nome, o modal fica com um tamanho incorreto, e não aparece o campo de texto para inserir o nome.

![image](https://user-images.githubusercontent.com/37812781/187048789-bf504025-c1e6-4b4d-9f61-5ee0fb375cd0.png)

## Solução
Ajuste de uma condição que decide o que aparece no modal de conexão.