### PR TITLE
fix: use connection debounce into load_people event

### DIFF
--- a/src/components/domain/connection-dialog/index.tsx
+++ b/src/components/domain/connection-dialog/index.tsx
@@ -87,7 +87,7 @@ function ConnectionDialog({ onRequestClose, isOpen }: ConnectionDialogProps) {
       clearTimeout(connectionDebounceTimer.current);
 
       if (connectionDebounceTimer.current > -1) {
-        window.setTimeout(() => {
+        connectionDebounceTimer.current = window.setTimeout(() => {
           setIsConnectingIntoRoom(false);
           connectionDebounceTimer.current = -1;
         }, 750);

--- a/src/components/domain/connection-dialog/index.tsx
+++ b/src/components/domain/connection-dialog/index.tsx
@@ -94,11 +94,18 @@ function ConnectionDialog({ onRequestClose, isOpen }: ConnectionDialogProps) {
       }
     }
 
+    const peopleID = room.subscription.pusher.sessionID;
+
     room.subscription.bind(MainRoomEvents.PEOPLE_ENTER, debounceConnectionLoad);
+    room.subscription.bind(`LOAD_PEOPLE:${peopleID}`, debounceConnectionLoad);
 
     return () => {
       room.subscription.unbind(
         MainRoomEvents.PEOPLE_ENTER,
+        debounceConnectionLoad
+      );
+      room.subscription.unbind(
+        `LOAD_PEOPLE:${peopleID}`,
         debounceConnectionLoad
       );
     };


### PR DESCRIPTION
## Motivação
Necessidade de tornar o carregamento de uma sala mais preciso

## Solução
Utilização do debounce de conexão no evento `LOAD_PEOPLE:${peopleID}`

close #22 