### PR TITLE
Feature/load user points

### DIFF
--- a/src/components/domain/connection-dialog/index.tsx
+++ b/src/components/domain/connection-dialog/index.tsx
@@ -28,11 +28,14 @@ function ConnectionDialog({
   basicRoomInfo,
 }: ConnectionDialogProps) {
   const router = useRouter();
-  const { connectOnRoom, disconnectOnRoom, room } = useRoomStore((state) => ({
-    connectOnRoom: state.connectOnRoom,
-    disconnectOnRoom: state.disconnectOnRoom,
-    room: state.basicInfo,
-  }));
+  const { connectOnRoom, disconnectOnRoom, room, connection } = useRoomStore(
+    (state) => ({
+      connectOnRoom: state.connectOnRoom,
+      disconnectOnRoom: state.disconnectOnRoom,
+      room: state.basicInfo,
+      connection: state.connection,
+    })
+  );
 
   const [isConnectingIntoRoom, setIsConnectingIntoRoom] = useState(true);
 
@@ -117,6 +120,7 @@ function ConnectionDialog({
 
     room.subscription.bind(MainRoomEvents.PREPARE_ROOM, debounceConnectionLoad);
     room.subscription.bind(MainRoomEvents.LOAD_PEOPLE, debounceConnectionLoad);
+    connection.bind(MainRoomEvents.SYNC_PEOPLE_POINTS, debounceConnectionLoad);
 
     debounceConnectionLoad();
 
@@ -127,6 +131,10 @@ function ConnectionDialog({
       );
       room.subscription.unbind(
         MainRoomEvents.LOAD_PEOPLE,
+        debounceConnectionLoad
+      );
+      connection.unbind(
+        MainRoomEvents.SYNC_PEOPLE_POINTS,
         debounceConnectionLoad
       );
     };

--- a/src/pages/api/sync-people-points.ts
+++ b/src/pages/api/sync-people-points.ts
@@ -1,0 +1,19 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { connectOnPusherServer } from "../../lib/pusher";
+import { MainRoomEvents } from "../../stores/room-store";
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse
+): Promise<NextApiResponse> => {
+  const { senderPeople, targetPeopleID } = req.body;
+
+  const pusher = connectOnPusherServer();
+
+  await pusher.sendToUser(targetPeopleID, MainRoomEvents.SYNC_PEOPLE_POINTS, {
+    id: senderPeople.id,
+    points: senderPeople.points,
+  });
+
+  return res.end();
+};

--- a/src/stores/room-store/types.ts
+++ b/src/stores/room-store/types.ts
@@ -1,4 +1,4 @@
-import { PresenceChannel } from "pusher-js";
+import pusherJs, { PresenceChannel } from "pusher-js";
 
 export interface People {
   id?: string;
@@ -11,6 +11,7 @@ export enum MainRoomEvents {
   PEOPLE_LEAVE = "pusher:member_removed",
   SELECT_POINT = "client-SELECT_POINT",
   SHOW_POINTS = "client-SHOW_POINTS",
+  SYNC_PEOPLE_POINTS = "people-SYNC_PEOPLE_POINTS",
   LOAD_PEOPLE = "pusher:member_added",
 }
 
@@ -44,6 +45,7 @@ export interface RoomStoreProps {
     subscription?: PresenceChannel;
   };
   peoples: People[];
+  connection?: pusherJs;
   createRoom(roomName: string): Promise<RoomInfo>;
   connectOnRoom(roomBasicInfo: BasicRoomInfo): Promise<() => void>;
   disconnectOnRoom(): void;


### PR DESCRIPTION
### Motivação
Atualmente ao entrar em uma sala em andamento, caso alguém tenha selecionado algum ponto, o usuário que entrou não obtém essa informação.

### Solução
Agora no momento em que um novo usuário entra em uma sala, ele pede a informação dos pontos selecionados de todos os membros.

close #9 