### PR TITLE
Refactor/standardize events

### DIFF
--- a/src/components/domain/connection-dialog/index.tsx
+++ b/src/components/domain/connection-dialog/index.tsx
@@ -3,7 +3,11 @@ import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 
-import { useRoomStore, MainRoomEvents } from "../../../stores/room-store";
+import {
+  useRoomStore,
+  InternalRoomEvents,
+  ClientRoomEvents,
+} from "../../../stores/room-store";
 import { useVisitsStore } from "../../../stores/visits-store";
 import Dialog from "../../ui/dialog";
 import { ConnectingMessage } from "./connecting-message";
@@ -128,23 +132,29 @@ function ConnectionDialog({
       }
     }
 
-    room.subscription.bind(MainRoomEvents.PREPARE_ROOM, debounceConnectionLoad);
-    room.subscription.bind(MainRoomEvents.LOAD_PEOPLE, debounceConnectionLoad);
-    connection.bind(MainRoomEvents.SYNC_PEOPLE_POINTS, debounceConnectionLoad);
+    room.subscription.bind(
+      InternalRoomEvents.PREPARE_ROOM,
+      debounceConnectionLoad
+    );
+    room.subscription.bind(
+      InternalRoomEvents.PEOPLE_ENTER,
+      debounceConnectionLoad
+    );
+    connection.bind(ClientRoomEvents.ROOM_SYNC_PEOPLE, debounceConnectionLoad);
 
     debounceConnectionLoad();
 
     return () => {
       room.subscription.unbind(
-        MainRoomEvents.PREPARE_ROOM,
+        InternalRoomEvents.PREPARE_ROOM,
         debounceConnectionLoad
       );
       room.subscription.unbind(
-        MainRoomEvents.LOAD_PEOPLE,
+        InternalRoomEvents.PEOPLE_ENTER,
         debounceConnectionLoad
       );
       connection.unbind(
-        MainRoomEvents.SYNC_PEOPLE_POINTS,
+        ClientRoomEvents.ROOM_SYNC_PEOPLE,
         debounceConnectionLoad
       );
     };

--- a/src/components/domain/connection-dialog/index.tsx
+++ b/src/components/domain/connection-dialog/index.tsx
@@ -2,12 +2,12 @@ import classNames from "classnames";
 import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
-
 import {
-  useRoomStore,
   InternalRoomEvents,
   ClientRoomEvents,
-} from "../../../stores/room-store";
+} from "../../../services/room-events";
+
+import { useRoomStore } from "../../../stores/room-store";
 import { useVisitsStore } from "../../../stores/visits-store";
 import Dialog from "../../ui/dialog";
 import { ConnectingMessage } from "./connecting-message";

--- a/src/components/domain/room-header/room-logo/index.tsx
+++ b/src/components/domain/room-header/room-logo/index.tsx
@@ -4,7 +4,8 @@ import toast from "react-hot-toast";
 import { BsFillSuitClubFill, BsPiggyBankFill } from "react-icons/bs";
 
 import { useConfetti } from "../../../../contexts/confetti-context";
-import { ClientRoomEvents, useRoomStore } from "../../../../stores/room-store";
+import { ClientRoomEvents } from "../../../../services/room-events";
+import { useRoomStore } from "../../../../stores/room-store";
 
 import styles from "./styles.module.css";
 

--- a/src/components/domain/room-header/room-logo/index.tsx
+++ b/src/components/domain/room-header/room-logo/index.tsx
@@ -4,7 +4,7 @@ import toast from "react-hot-toast";
 import { BsFillSuitClubFill, BsPiggyBankFill } from "react-icons/bs";
 
 import { useConfetti } from "../../../../contexts/confetti-context";
-import { MainRoomEvents, useRoomStore } from "../../../../stores/room-store";
+import { ClientRoomEvents, useRoomStore } from "../../../../stores/room-store";
 
 import styles from "./styles.module.css";
 
@@ -37,13 +37,13 @@ function RoomLogo() {
     }
 
     roomSubscription.bind(
-      MainRoomEvents.FIRE_CONFETTI,
+      ClientRoomEvents.PEOPLE_FIRE_CONFETTI,
       ({ sender_id }: { sender_id: string }) =>
         showEasterEggConfettis(EasterEggMode.PRIVATE, sender_id)
     );
 
     return () => {
-      roomSubscription.unbind(MainRoomEvents.FIRE_CONFETTI);
+      roomSubscription.unbind(ClientRoomEvents.PEOPLE_FIRE_CONFETTI);
     };
   }, [roomSubscription]);
 

--- a/src/pages/api/save-events.ts
+++ b/src/pages/api/save-events.ts
@@ -3,7 +3,7 @@ import type { Event as AmplitudeEvent } from "@amplitude/node";
 
 import { amplitude } from "../../lib/amplitude";
 import { usePusherWebhook } from "../../hooks/use-pusher-webhook";
-import { InternalRoomEvents } from "../../stores/room-store";
+import { InternalRoomEvents } from "../../services/room-events";
 
 const eventTypeParsers = {
   member_added: InternalRoomEvents.PEOPLE_ENTER,

--- a/src/pages/api/save-events.ts
+++ b/src/pages/api/save-events.ts
@@ -34,7 +34,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     switch (parsedEventType) {
       case VaultEvent.room_show_points:
         await eventVault[parsedEventType]({
-          event_sended_at: parsedEventData.room_countdown_started_at,
+          event_sended_at: new Date(parsedEventData.room_countdown_started_at),
           people_id: parsedEventData.people_id,
           room_id: parsedRoomID,
           show_points: parsedEventData.show_points,

--- a/src/pages/api/save-events.ts
+++ b/src/pages/api/save-events.ts
@@ -34,10 +34,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     switch (parsedEventType) {
       case VaultEvent.room_show_points:
         await eventVault[parsedEventType]({
-          event_sended_at: eventsSendedAt,
+          event_sended_at: parsedEventData.room_countdown_started_at,
           people_id: parsedEventData.people_id,
           room_id: parsedRoomID,
-          countdown_started_at: parsedEventData.room_countdown_started_at,
           show_points: parsedEventData.show_points,
         });
         break;

--- a/src/pages/api/save-events.ts
+++ b/src/pages/api/save-events.ts
@@ -3,11 +3,11 @@ import type { Event as AmplitudeEvent } from "@amplitude/node";
 
 import { amplitude } from "../../lib/amplitude";
 import { usePusherWebhook } from "../../hooks/use-pusher-webhook";
-import { MainRoomEvents } from "../../stores/room-store";
+import { InternalRoomEvents } from "../../stores/room-store";
 
 const eventTypeParsers = {
-  member_added: MainRoomEvents.LOAD_PEOPLE,
-  member_removed: MainRoomEvents.PEOPLE_LEAVE,
+  member_added: InternalRoomEvents.PEOPLE_ENTER,
+  member_removed: InternalRoomEvents.PEOPLE_LEAVE,
 };
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {

--- a/src/pages/api/save-events.ts
+++ b/src/pages/api/save-events.ts
@@ -1,13 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import type { Event as AmplitudeEvent } from "@amplitude/node";
 
-import { amplitude } from "../../lib/amplitude";
 import { usePusherWebhook } from "../../hooks/use-pusher-webhook";
-import { InternalRoomEvents } from "../../services/room-events";
+import { ClientRoomEvents } from "../../services/room-events";
+import { VaultEvent } from "../../services/event-vault/types";
+import { eventVault } from "../../services/event-vault";
 
 const eventTypeParsers = {
-  member_added: InternalRoomEvents.PEOPLE_ENTER,
-  member_removed: InternalRoomEvents.PEOPLE_LEAVE,
+  member_added: VaultEvent.room_people_enter,
+  member_removed: VaultEvent.room_people_leave,
+  [ClientRoomEvents.PEOPLE_FIRE_CONFETTI]: VaultEvent.people_fire_confetti,
+  [ClientRoomEvents.PEOPLE_SELECT_POINT]: VaultEvent.people_select_point,
+  [ClientRoomEvents.ROOM_SHOW_POINTS]: VaultEvent.room_show_points,
 };
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
@@ -23,25 +26,38 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   for (const event of events) {
     const parsedRoomID = event.channel.replace("presence-", "");
 
-    const parsedEventType: string =
-      event?.event || eventTypeParsers?.[event?.name];
+    const parsedEventType: VaultEvent =
+      eventTypeParsers?.[event?.event || event?.name];
 
-    const parsedEvent: AmplitudeEvent = {
-      event_type: parsedEventType,
-      user_id: event.user_id,
-      platform: "my-planning-poker",
-      event_properties: {
-        room_id: parsedRoomID,
-        sended_at: eventsSendedAt,
-        environment: process.env.VERCEL_ENV,
-      },
-      user_properties: event?.data ? JSON.parse(event.data) : undefined,
-    };
+    const parsedEventData = JSON.parse(event.data || "{}");
 
-    const eventResponse = await amplitude.logEvent(parsedEvent);
+    switch (parsedEventType) {
+      case VaultEvent.room_show_points:
+        await eventVault[parsedEventType]({
+          event_sended_at: eventsSendedAt,
+          people_id: parsedEventData.people_id,
+          room_id: parsedRoomID,
+          countdown_started_at: parsedEventData.room_countdown_started_at,
+          show_points: parsedEventData.show_points,
+        });
+        break;
 
-    if (eventResponse.statusCode !== 200) {
-      throw new Error(`Event "${event.event}" not sent`);
+      case VaultEvent.people_select_point:
+        await eventVault[parsedEventType]({
+          event_sended_at: eventsSendedAt,
+          people_id: parsedEventData.people_id,
+          room_id: parsedRoomID,
+          people_selected_points: parsedEventData.people_selected_points,
+        });
+        break;
+
+      default:
+        await eventVault[parsedEventType]({
+          event_sended_at: eventsSendedAt,
+          people_id: parsedEventData.people_id,
+          room_id: parsedRoomID,
+        });
+        break;
     }
   }
 

--- a/src/pages/api/save-events.ts
+++ b/src/pages/api/save-events.ts
@@ -35,7 +35,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       case VaultEvent.room_show_points:
         await eventVault[parsedEventType]({
           event_sended_at: new Date(parsedEventData.room_countdown_started_at),
-          people_id: parsedEventData.people_id,
+          people_id: event.user_id,
           room_id: parsedRoomID,
           show_points: parsedEventData.show_points,
         });
@@ -44,7 +44,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       case VaultEvent.people_select_point:
         await eventVault[parsedEventType]({
           event_sended_at: eventsSendedAt,
-          people_id: parsedEventData.people_id,
+          people_id: event.user_id,
           room_id: parsedRoomID,
           people_selected_points: parsedEventData.people_selected_points,
         });
@@ -53,7 +53,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       default:
         await eventVault[parsedEventType]({
           event_sended_at: eventsSendedAt,
-          people_id: parsedEventData.people_id,
+          people_id: event.user_id,
           room_id: parsedRoomID,
         });
         break;

--- a/src/pages/api/sync-people.ts
+++ b/src/pages/api/sync-people.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { connectOnPusherServer } from "../../lib/pusher";
-import { ClientRoomEvents } from "../../services/room-events";
+import { roomEvents } from "../../services/room-events";
 
 export default async (
   req: NextApiRequest,
@@ -10,10 +10,11 @@ export default async (
 
   const pusher = connectOnPusherServer();
 
-  await pusher.sendToUser(targetPeopleID, ClientRoomEvents.ROOM_SYNC_PEOPLE, {
-    id: senderPeople.id,
-    points: senderPeople.points,
-    countdownStartedAt,
+  await roomEvents.onRoomSyncPeople(pusher, {
+    people_id: senderPeople.id,
+    selected_points: senderPeople.points,
+    target_people_id: targetPeopleID,
+    room_countdown_started_at: countdownStartedAt,
   });
 
   return res.end();

--- a/src/pages/api/sync-people.ts
+++ b/src/pages/api/sync-people.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { connectOnPusherServer } from "../../lib/pusher";
-import { ClientRoomEvents } from "../../stores/room-store";
+import { ClientRoomEvents } from "../../services/room-events";
 
 export default async (
   req: NextApiRequest,

--- a/src/pages/api/sync-people.ts
+++ b/src/pages/api/sync-people.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { connectOnPusherServer } from "../../lib/pusher";
-import { MainRoomEvents } from "../../stores/room-store";
+import { ClientRoomEvents } from "../../stores/room-store";
 
 export default async (
   req: NextApiRequest,
@@ -10,7 +10,7 @@ export default async (
 
   const pusher = connectOnPusherServer();
 
-  await pusher.sendToUser(targetPeopleID, MainRoomEvents.SYNC_PEOPLE_POINTS, {
+  await pusher.sendToUser(targetPeopleID, ClientRoomEvents.ROOM_SYNC_PEOPLE, {
     id: senderPeople.id,
     points: senderPeople.points,
     countdownStartedAt,

--- a/src/services/event-vault/index.ts
+++ b/src/services/event-vault/index.ts
@@ -25,7 +25,6 @@ async function onRoomShowPoints(
     event_properties: {
       show_points: props.show_points,
     },
-    time: props.countdown_started_at,
   });
 
   await amplitude.logEvent(event);

--- a/src/services/event-vault/index.ts
+++ b/src/services/event-vault/index.ts
@@ -1,0 +1,60 @@
+import { amplitude } from "../../lib/amplitude";
+import { VaultEventHandlers, VaultEvent } from "./types";
+import { prepareBasicEvent } from "./utils";
+
+async function onRoomPeopleEnter(
+  props: VaultEventHandlers.OnRoomPeopleEnterProps
+) {
+  const event = prepareBasicEvent(VaultEvent.room_people_enter, props);
+
+  await amplitude.logEvent(event);
+}
+
+async function onRoomPeopleLeave(
+  props: VaultEventHandlers.OnRoomPeopleLeaveProps
+) {
+  const event = prepareBasicEvent(VaultEvent.room_people_leave, props);
+
+  await amplitude.logEvent(event);
+}
+
+async function onRoomShowPoints(
+  props: VaultEventHandlers.OnRoomShowPointsProps
+) {
+  const event = prepareBasicEvent(VaultEvent.room_show_points, props, {
+    event_properties: {
+      show_points: props.show_points,
+    },
+    time: props.countdown_started_at,
+  });
+
+  await amplitude.logEvent(event);
+}
+
+async function onPeopleSelectPoint(
+  props: VaultEventHandlers.OnPeopleSelectPointProps
+) {
+  const event = prepareBasicEvent(VaultEvent.people_select_point, props, {
+    event_properties: {
+      people_selected_points: props.people_selected_points,
+    },
+  });
+
+  await amplitude.logEvent(event);
+}
+
+async function onPeopleFireConfetti(
+  props: VaultEventHandlers.OnPeopleFireConfettiProps
+) {
+  const event = prepareBasicEvent(VaultEvent.people_fire_confetti, props);
+
+  await amplitude.logEvent(event);
+}
+
+export const eventVault = {
+  [VaultEvent.room_people_enter]: onRoomPeopleEnter,
+  [VaultEvent.room_people_leave]: onRoomPeopleLeave,
+  [VaultEvent.room_show_points]: onRoomShowPoints,
+  [VaultEvent.people_select_point]: onPeopleSelectPoint,
+  [VaultEvent.people_fire_confetti]: onPeopleFireConfetti,
+};

--- a/src/services/event-vault/types.ts
+++ b/src/services/event-vault/types.ts
@@ -19,7 +19,6 @@ export namespace VaultEventHandlers {
 
   export interface OnRoomShowPointsProps extends BasicEventProps {
     show_points: boolean;
-    countdown_started_at: number;
   }
 
   export interface OnPeopleSelectPointProps extends BasicEventProps {

--- a/src/services/event-vault/types.ts
+++ b/src/services/event-vault/types.ts
@@ -1,0 +1,30 @@
+export enum VaultEvent {
+  room_people_enter = "mpp_room_people_enter",
+  room_people_leave = "mpp_room_people_leave",
+  room_show_points = "mpp_room_show_points",
+  people_select_point = "mpp_people_select_point",
+  people_fire_confetti = "mpp_people_fire_confetti",
+}
+
+export namespace VaultEventHandlers {
+  export interface BasicEventProps {
+    room_id: string;
+    people_id: string;
+    event_sended_at: Date;
+  }
+
+  export interface OnRoomPeopleEnterProps extends BasicEventProps {}
+
+  export interface OnRoomPeopleLeaveProps extends BasicEventProps {}
+
+  export interface OnRoomShowPointsProps extends BasicEventProps {
+    show_points: boolean;
+    countdown_started_at: number;
+  }
+
+  export interface OnPeopleSelectPointProps extends BasicEventProps {
+    people_selected_points: number;
+  }
+
+  export interface OnPeopleFireConfettiProps extends BasicEventProps {}
+}

--- a/src/services/event-vault/utils.ts
+++ b/src/services/event-vault/utils.ts
@@ -1,0 +1,21 @@
+import _ from "lodash";
+import type { Event as AmplitudeEvent } from "@amplitude/node";
+import { VaultEvent, VaultEventHandlers } from "./types";
+
+export function prepareBasicEvent(
+  eventType: VaultEvent,
+  basicProps: VaultEventHandlers.BasicEventProps,
+  restEvent?: Partial<AmplitudeEvent>
+): AmplitudeEvent {
+  const basicEvent: AmplitudeEvent = {
+    event_type: eventType,
+    user_id: basicProps.people_id,
+    event_properties: {
+      room_id: basicProps.room_id,
+      environment: process.env.VERCEL_ENV,
+    },
+    time: basicProps.event_sended_at.getTime(),
+  };
+
+  return _.merge(basicEvent, restEvent);
+}

--- a/src/services/room-events/index.ts
+++ b/src/services/room-events/index.ts
@@ -1,27 +1,29 @@
+import Pusher from "pusher";
 import { PresenceChannel } from "pusher-js";
 import {
   ClientRoomEvents,
   OnPeopleFireConfettiProps,
   OnPeopleSelectPointProps,
   OnRoomShowPointsProps,
+  OnRoomSyncPeopleProps,
 } from "./types";
 
 function onPeopleSelectPoint(
   subscription: PresenceChannel,
-  { people_has_selected_points, people_id }: OnPeopleSelectPointProps
+  { people_selected_points, people_id }: OnPeopleSelectPointProps
 ) {
   subscription.trigger(ClientRoomEvents.PEOPLE_SELECT_POINT, {
-    people_has_selected_points,
+    people_selected_points,
     people_id,
   });
 }
 
 function onRoomShowPoints(
   subscription: PresenceChannel,
-  { countdown_started_at, show_points }: OnRoomShowPointsProps
+  { room_countdown_started_at, show_points }: OnRoomShowPointsProps
 ) {
   subscription.trigger(ClientRoomEvents.ROOM_SHOW_POINTS, {
-    countdown_started_at,
+    room_countdown_started_at,
     show_points,
   });
 }
@@ -35,9 +37,30 @@ function onPeopleFireConfetti(
   });
 }
 
+async function onRoomSyncPeople(
+  pusherClient: Pusher,
+  {
+    people_id,
+    selected_points,
+    target_people_id,
+    room_countdown_started_at,
+  }: OnRoomSyncPeopleProps
+) {
+  await pusherClient.sendToUser(
+    target_people_id,
+    ClientRoomEvents.ROOM_SYNC_PEOPLE,
+    {
+      people_id,
+      selected_points,
+      room_countdown_started_at,
+    }
+  );
+}
+
 export const roomEvents = {
   onPeopleFireConfetti,
   onPeopleSelectPoint,
   onRoomShowPoints,
+  onRoomSyncPeople,
 };
-export { InternalRoomEvents, ClientRoomEvents } from "./types";
+export * from "./types";

--- a/src/services/room-events/index.ts
+++ b/src/services/room-events/index.ts
@@ -1,0 +1,43 @@
+import { PresenceChannel } from "pusher-js";
+import {
+  ClientRoomEvents,
+  OnPeopleFireConfettiProps,
+  OnPeopleSelectPointProps,
+  OnRoomShowPointsProps,
+} from "./types";
+
+function onPeopleSelectPoint(
+  subscription: PresenceChannel,
+  { people_has_selected_points, people_id }: OnPeopleSelectPointProps
+) {
+  subscription.trigger(ClientRoomEvents.PEOPLE_SELECT_POINT, {
+    people_has_selected_points,
+    people_id,
+  });
+}
+
+function onRoomShowPoints(
+  subscription: PresenceChannel,
+  { countdown_started_at, show_points }: OnRoomShowPointsProps
+) {
+  subscription.trigger(ClientRoomEvents.ROOM_SHOW_POINTS, {
+    countdown_started_at,
+    show_points,
+  });
+}
+
+function onPeopleFireConfetti(
+  subscription: PresenceChannel,
+  { people_id }: OnPeopleFireConfettiProps
+) {
+  subscription.trigger(ClientRoomEvents.PEOPLE_FIRE_CONFETTI, {
+    people_id,
+  });
+}
+
+export const roomEvents = {
+  onPeopleFireConfetti,
+  onPeopleSelectPoint,
+  onRoomShowPoints,
+};
+export { InternalRoomEvents, ClientRoomEvents } from "./types";

--- a/src/services/room-events/types.ts
+++ b/src/services/room-events/types.ts
@@ -1,0 +1,26 @@
+export enum InternalRoomEvents {
+  PEOPLE_ENTER = "pusher:member_added",
+  PEOPLE_LEAVE = "pusher:member_removed",
+  PREPARE_ROOM = "pusher:subscription_succeeded",
+}
+
+export enum ClientRoomEvents {
+  ROOM_SYNC_PEOPLE = "people-ROOM_SYNC_PEOPLE",
+  ROOM_SHOW_POINTS = "client-room_show_points",
+  PEOPLE_SELECT_POINT = "client-people_select_point",
+  PEOPLE_FIRE_CONFETTI = "client-people_fire_confetti",
+}
+
+export interface OnPeopleSelectPointProps {
+  people_id: string;
+  people_has_selected_points: boolean;
+}
+
+export interface OnRoomShowPointsProps {
+  show_points: boolean;
+  countdown_started_at: number;
+}
+
+export interface OnPeopleFireConfettiProps {
+  people_id: string;
+}

--- a/src/services/room-events/types.ts
+++ b/src/services/room-events/types.ts
@@ -13,14 +13,21 @@ export enum ClientRoomEvents {
 
 export interface OnPeopleSelectPointProps {
   people_id: string;
-  people_has_selected_points: boolean;
+  people_selected_points: number;
 }
 
 export interface OnRoomShowPointsProps {
   show_points: boolean;
-  countdown_started_at: number;
+  room_countdown_started_at: number;
 }
 
 export interface OnPeopleFireConfettiProps {
   people_id: string;
+}
+
+export interface OnRoomSyncPeopleProps {
+  target_people_id: string;
+  people_id: string;
+  selected_points: number;
+  room_countdown_started_at?: number;
 }

--- a/src/stores/room-store/index.ts
+++ b/src/stores/room-store/index.ts
@@ -8,6 +8,7 @@ import { createWebConnection } from "../../lib/pusher";
 import {
   InternalRoomEvents,
   ClientRoomEvents,
+  roomEvents,
 } from "../../services/room-events";
 import { BasicRoomInfo, EventMode, RoomInfo, RoomStoreProps } from "./types";
 
@@ -151,13 +152,13 @@ const roomStore: StateCreator<RoomStoreProps, [], [], RoomStoreProps> = (
     const myID = basicInfo.subscription.members.myID;
 
     roomHandler.onSelectPoint({
-      id: myID,
-      points,
+      people_id: myID,
+      people_selected_points: points,
     });
 
-    basicInfo.subscription.trigger(ClientRoomEvents.PEOPLE_SELECT_POINT, {
-      id: myID,
-      points,
+    roomEvents.onPeopleSelectPoint(basicInfo.subscription, {
+      people_id: myID,
+      people_selected_points: points,
     });
   }
 
@@ -169,13 +170,16 @@ const roomStore: StateCreator<RoomStoreProps, [], [], RoomStoreProps> = (
     const { basicInfo } = get();
 
     if (mode === EventMode.PUBLIC) {
-      basicInfo.subscription.trigger(ClientRoomEvents.ROOM_SHOW_POINTS, {
-        show,
-        startedAt,
+      roomEvents.onRoomShowPoints(basicInfo.subscription, {
+        show_points: show,
+        room_countdown_started_at: startedAt,
       });
     }
 
-    roomHandler.onShowPoints({ show, startedAt });
+    roomHandler.onShowPoints({
+      show_points: show,
+      room_countdown_started_at: startedAt,
+    });
   }
 
   function setEasterEggVisibility(show: boolean) {
@@ -185,8 +189,8 @@ const roomStore: StateCreator<RoomStoreProps, [], [], RoomStoreProps> = (
   function broadcastConfetti() {
     const { basicInfo } = get();
 
-    basicInfo.subscription.trigger(ClientRoomEvents.PEOPLE_FIRE_CONFETTI, {
-      sender_id: basicInfo.subscription.members.myID,
+    roomEvents.onPeopleFireConfetti(basicInfo.subscription, {
+      people_id: basicInfo.subscription.members.myID,
     });
   }
 

--- a/src/stores/room-store/mount-room-events.ts
+++ b/src/stores/room-store/mount-room-events.ts
@@ -130,6 +130,7 @@ export function mountRoomEvents(
         state.basicInfo.showPoints = show;
 
         if (!show) {
+          state.basicInfo.countdownStartedAt = undefined;
           state.peoples = state.peoples.map((people) => ({
             ...people,
             points: undefined,

--- a/src/stores/room-store/mount-room-handler.ts
+++ b/src/stores/room-store/mount-room-handler.ts
@@ -7,11 +7,10 @@ import {
   MountRoomEventsProps,
   OnHighlightPeopleProps,
   OnLoadPeopleProps,
-  OnShowPointsProps,
-  OnSyncPeopleProps,
   People,
   RoomStoreProps,
 } from "./types";
+import * as RoomEvents from "../../services/room-events";
 
 function sortPeoplesByArrival(peoples: People[]) {
   return _.sortBy(peoples, ["entered_at"], ["asc"]);
@@ -73,26 +72,32 @@ export function mountRoomHandler(
     }));
   }
 
-  function onSelectPoint(people: Pick<People, "id" | "points">) {
+  function onSelectPoint({
+    people_id,
+    people_selected_points,
+  }: RoomEvents.OnPeopleSelectPointProps) {
     set((state) => ({
       peoples: state.peoples.map((statePeople) =>
-        statePeople.id === people.id
+        statePeople.id === people_id
           ? {
               ...statePeople,
-              points: people.points,
+              points: people_selected_points,
             }
           : statePeople
       ),
     }));
   }
 
-  function onShowPoints({ show, startedAt }: OnShowPointsProps) {
-    if (show) {
+  function onShowPoints({
+    show_points,
+    room_countdown_started_at,
+  }: RoomEvents.OnRoomShowPointsProps) {
+    if (show_points) {
       const ONE_SECOND = 1000;
       const MAX_COUNTDOWN = 5;
 
       const currentTime = Date.now();
-      const startDelay = (currentTime - startedAt) / 1000;
+      const startDelay = (currentTime - room_countdown_started_at) / 1000;
       const firstCountdown = MAX_COUNTDOWN - Math.floor(startDelay);
 
       const parsedFirstCountdown = firstCountdown >= 0 ? firstCountdown : 0;
@@ -103,7 +108,7 @@ export function mountRoomHandler(
       set(
         produce((state: RoomStoreProps) => {
           state.basicInfo.showPointsCountdown = parsedFirstCountdown;
-          state.basicInfo.countdownStartedAt = startedAt;
+          state.basicInfo.countdownStartedAt = room_countdown_started_at;
         })
       );
 
@@ -127,9 +132,9 @@ export function mountRoomHandler(
 
     set(
       produce((state: RoomStoreProps) => {
-        state.basicInfo.showPoints = show;
+        state.basicInfo.showPoints = show_points;
 
-        if (!show) {
+        if (!show_points) {
           state.basicInfo.countdownStartedAt = undefined;
           state.peoples = state.peoples.map((people) => ({
             ...people,
@@ -140,25 +145,26 @@ export function mountRoomHandler(
     );
   }
 
-  function onSyncPeople(senderPeople: OnSyncPeopleProps) {
+  function onSyncPeople({
+    people_id,
+    selected_points,
+    room_countdown_started_at,
+  }: RoomEvents.OnRoomSyncPeopleProps) {
     const state = get();
 
     const updatedPeoplesList = state.peoples.map((people) =>
-      people.id === senderPeople.id
+      people.id === people_id
         ? {
             ...people,
-            points: senderPeople.points,
+            points: selected_points,
           }
         : people
     );
 
-    if (
-      !state.basicInfo.countdownStartedAt &&
-      senderPeople.countdownStartedAt
-    ) {
+    if (!state.basicInfo.countdownStartedAt && room_countdown_started_at) {
       onShowPoints({
-        show: true,
-        startedAt: senderPeople.countdownStartedAt,
+        show_points: true,
+        room_countdown_started_at,
       });
     }
 

--- a/src/stores/room-store/mount-room-handler.ts
+++ b/src/stores/room-store/mount-room-handler.ts
@@ -17,7 +17,7 @@ function sortPeoplesByArrival(peoples: People[]) {
   return _.sortBy(peoples, ["entered_at"], ["asc"]);
 }
 
-export function mountRoomEvents(
+export function mountRoomHandler(
   set: MountRoomEventsProps[0],
   get: MountRoomEventsProps[1]
 ) {

--- a/src/stores/room-store/types.ts
+++ b/src/stores/room-store/types.ts
@@ -14,14 +14,17 @@ export interface People {
   highlight?: boolean;
 }
 
-export enum MainRoomEvents {
-  PREPARE_ROOM = "pusher:subscription_succeeded",
+export enum InternalRoomEvents {
+  PEOPLE_ENTER = "pusher:member_added",
   PEOPLE_LEAVE = "pusher:member_removed",
-  SELECT_POINT = "client-SELECT_POINT",
-  SHOW_POINTS = "client-SHOW_POINTS",
-  SYNC_PEOPLE_POINTS = "people-SYNC_PEOPLE_POINTS",
-  LOAD_PEOPLE = "pusher:member_added",
-  FIRE_CONFETTI = "client-FIRE_CONFETTI",
+  PREPARE_ROOM = "pusher:subscription_succeeded",
+}
+
+export enum ClientRoomEvents {
+  ROOM_SYNC_PEOPLE = "people-ROOM_SYNC_PEOPLE",
+  ROOM_SHOW_POINTS = "client-room_show_points",
+  PEOPLE_SELECT_POINT = "client-people_select_point",
+  PEOPLE_FIRE_CONFETTI = "client-people_fire_confetti",
 }
 
 export interface RoomInfo {

--- a/src/stores/room-store/types.ts
+++ b/src/stores/room-store/types.ts
@@ -73,11 +73,6 @@ export interface OnLoadPeopleProps {
   };
 }
 
-export interface OnShowPointsProps {
-  show: boolean;
-  startedAt: number;
-}
-
 export interface OnSyncPeopleProps {
   id: string;
   points: number;

--- a/src/stores/room-store/types.ts
+++ b/src/stores/room-store/types.ts
@@ -14,19 +14,6 @@ export interface People {
   highlight?: boolean;
 }
 
-export enum InternalRoomEvents {
-  PEOPLE_ENTER = "pusher:member_added",
-  PEOPLE_LEAVE = "pusher:member_removed",
-  PREPARE_ROOM = "pusher:subscription_succeeded",
-}
-
-export enum ClientRoomEvents {
-  ROOM_SYNC_PEOPLE = "people-ROOM_SYNC_PEOPLE",
-  ROOM_SHOW_POINTS = "client-room_show_points",
-  PEOPLE_SELECT_POINT = "client-people_select_point",
-  PEOPLE_FIRE_CONFETTI = "client-people_fire_confetti",
-}
-
 export interface RoomInfo {
   name: string;
   id: string;


### PR DESCRIPTION
### Motivação
Atualmente os eventos do Pusher e do Amplitude não estão padronizados, o que pode acarretar uma bagunça no futuro.

### Solução
Padronização dos eventos do Pusher e do Amplitude, de uma forma legível e simples.
