### PR TITLE
Refactor/separate pusher apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ dist-ssr
 
 # Sentry
 .sentryclirc
+
+.vercel

--- a/src/lib/pusher.ts
+++ b/src/lib/pusher.ts
@@ -3,7 +3,7 @@ import PusherWeb from "pusher-js";
 
 export function connectOnPusherWeb() {
   const pusher = new PusherWeb(process.env.NEXT_PUBLIC_PUSHER_KEY, {
-    cluster: "us2",
+    cluster: process.env.NEXT_PUBLIC_PUSHER_CLUSTER,
     channelAuthorization: {
       endpoint: "/api/auth/channel",
       transport: "ajax",
@@ -22,7 +22,7 @@ export function connectOnPusherServer() {
     appId: process.env.PUSHER_APP_ID,
     key: process.env.NEXT_PUBLIC_PUSHER_KEY,
     secret: process.env.PUSHER_SECRET,
-    cluster: "us2",
+    cluster: process.env.NEXT_PUBLIC_PUSHER_CLUSTER,
     useTLS: true,
   });
 

--- a/src/pages/api/save-events.ts
+++ b/src/pages/api/save-events.ts
@@ -14,6 +14,8 @@ const eventTypeParsers = {
 };
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const eventEnvironmentOrigin = String(req.query.environment);
+
   const { events, eventsSendedAt, webhookIsValid } = usePusherWebhook({
     body: req.body,
     headers: req.headers,
@@ -37,6 +39,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
           event_sended_at: new Date(parsedEventData.room_countdown_started_at),
           people_id: event.user_id,
           room_id: parsedRoomID,
+          environment: eventEnvironmentOrigin,
           show_points: parsedEventData.show_points,
         });
         break;
@@ -46,6 +49,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
           event_sended_at: eventsSendedAt,
           people_id: event.user_id,
           room_id: parsedRoomID,
+          environment: eventEnvironmentOrigin,
           people_selected_points: parsedEventData.people_selected_points,
         });
         break;
@@ -55,6 +59,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
           event_sended_at: eventsSendedAt,
           people_id: event.user_id,
           room_id: parsedRoomID,
+          environment: eventEnvironmentOrigin,
         });
         break;
     }

--- a/src/services/event-vault/types.ts
+++ b/src/services/event-vault/types.ts
@@ -11,6 +11,7 @@ export namespace VaultEventHandlers {
     room_id: string;
     people_id: string;
     event_sended_at: Date;
+    environment: string;
   }
 
   export interface OnRoomPeopleEnterProps extends BasicEventProps {}

--- a/src/services/event-vault/utils.ts
+++ b/src/services/event-vault/utils.ts
@@ -12,7 +12,7 @@ export function prepareBasicEvent(
     user_id: basicProps.people_id,
     event_properties: {
       room_id: basicProps.room_id,
-      environment: process.env.VERCEL_ENV,
+      environment: basicProps.environment,
     },
     time: basicProps.event_sended_at.getTime(),
   };


### PR DESCRIPTION
### Motivação
Atualmente todos os ambientes compartilham do mesmo canal do Pusher, e com isso não é possível saber com precisam a origem dos eventos disparados.

### Solução
- Criação de novos canais do Pusher;
![image](https://user-images.githubusercontent.com/37812781/196297676-4144ee54-7ccb-4402-87fd-ebe77f8f3701.png)

- Implementação de um mecanismo que permite saber a origem do evento, separando por ambientes que são passados via query param para a rota que cuida dos eventos.



closes #15 #58 