### PR TITLE
Fix/prevent feedback while loading

### DIFF
--- a/src/components/domain/feedback-dialog/index.tsx
+++ b/src/components/domain/feedback-dialog/index.tsx
@@ -112,7 +112,7 @@ export function FeedbackDialog() {
               <TextArea
                 title="Descrição"
                 rows={5}
-                disabled={!isFilledFeedbackType}
+                disabled={isSendingFeedback || !isFilledFeedbackType}
                 required
                 ref={descriptionRef}
               />


### PR DESCRIPTION
### Motivação
Atualmente o campo de texto de feedback permanece habilitado mesmo enquanto o feedback é enviado, e isso pode causar problemas.

### Solução
Campo de texto de feedback desabilitado enquanto o envio acontece.