### PR TITLE
Fix/timezone normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@upstash/redis": "^1.12.0",
     "axios": "^0.27.2",
     "classnames": "^2.3.1",
+    "dayjs": "^1.11.7",
     "immer": "^9.0.15",
     "lodash": "^4.17.20",
     "next": "^12.2.5",

--- a/src/components/domain/connection-dialog/people-form/index.tsx
+++ b/src/components/domain/connection-dialog/people-form/index.tsx
@@ -47,7 +47,7 @@ function PeopleForm({
           >
             Cancelar
           </Button>
-          <Button>Entrar na sala</Button>
+          <Button type="submit">Entrar na sala</Button>
         </div>
       </form>
     </>

--- a/src/components/domain/room-header/room-logo/index.tsx
+++ b/src/components/domain/room-header/room-logo/index.tsx
@@ -39,8 +39,8 @@ function RoomLogo() {
 
     roomSubscription.bind(
       ClientRoomEvents.PEOPLE_FIRE_CONFETTI,
-      ({ sender_id }: { sender_id: string }) =>
-        showEasterEggConfettis(EasterEggMode.PRIVATE, sender_id)
+      ({ people_id }: { people_id: string }) =>
+        showEasterEggConfettis(EasterEggMode.PRIVATE, people_id)
     );
 
     return () => {

--- a/src/lib/dayjs.ts
+++ b/src/lib/dayjs.ts
@@ -1,0 +1,8 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export { dayjs };

--- a/src/stores/room-store/index.ts
+++ b/src/stores/room-store/index.ts
@@ -10,6 +10,7 @@ import {
   ClientRoomEvents,
   roomEvents,
 } from "../../services/room-events";
+import { getDateWithTimezone } from "../../utils/get-date-with-timezone";
 import { BasicRoomInfo, EventMode, RoomInfo, RoomStoreProps } from "./types";
 
 let connection: pusherJs;
@@ -164,7 +165,7 @@ const roomStore: StateCreator<RoomStoreProps, [], [], RoomStoreProps> = (
 
   async function setRoomPointsVisibility(
     show?: boolean,
-    startedAt = Date.now(),
+    startedAt = getDateWithTimezone().getTime(),
     mode: EventMode = EventMode.PUBLIC
   ) {
     const { basicInfo } = get();

--- a/src/stores/room-store/mount-room-handler.ts
+++ b/src/stores/room-store/mount-room-handler.ts
@@ -11,6 +11,7 @@ import {
   RoomStoreProps,
 } from "./types";
 import * as RoomEvents from "../../services/room-events";
+import { getDateWithTimezone } from "../../utils/get-date-with-timezone";
 
 function sortPeoplesByArrival(peoples: People[]) {
   return sortBy(peoples, ["entered_at"], ["asc"]);
@@ -96,7 +97,7 @@ export function mountRoomHandler(
       const ONE_SECOND = 1000;
       const MAX_COUNTDOWN = 5;
 
-      const currentTime = Date.now();
+      const currentTime = getDateWithTimezone().getTime();
       const startDelay = (currentTime - room_countdown_started_at) / 1000;
       const firstCountdown = MAX_COUNTDOWN - Math.floor(startDelay);
 

--- a/src/utils/get-date-with-timezone.ts
+++ b/src/utils/get-date-with-timezone.ts
@@ -1,0 +1,13 @@
+import { dayjs } from "../lib/dayjs";
+
+enum TimeZone {
+  AMERICA_SAO_PAULO = "America/Sao_Paulo",
+  AMERICA_LIMA = "America/Lima",
+}
+
+export function getDateWithTimezone(
+  date = new Date(),
+  timeZone = TimeZone.AMERICA_SAO_PAULO
+) {
+  return dayjs(date).tz(timeZone).toDate();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1793,6 +1793,11 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
   integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
 
+dayjs@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
+  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
+
 debug@4, debug@^4.1.0, debug@^4.1.1:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"


### PR DESCRIPTION
### Motivação
- Quando há uma diferencia de timezones, a contagem regressiva não ocorre de forma correta;
- Quando o confete é disparado, o card de quem disparou não fica em destaque para todos;
- O botão "Entrar na sala" no caso de o usuário tentar entrar sem um nome definido não funciona.

### Solução
- Normalização dos timezones para `America/Sao_Paulo`;
- Passagem correta da propriedade que indica o ID de quem disparou o confete;
- Adição do `type="submit"` no botão "Entrar na sala".