### PR TITLE
Fix/simple countdown

### DIFF
--- a/src/hooks/use-debounce.ts
+++ b/src/hooks/use-debounce.ts
@@ -1,0 +1,15 @@
+import { useRef } from "react";
+
+export function useDebounce(delay: number, outerAction?: Function) {
+  const debounceTimerRef = useRef(0);
+
+  function debounce(innerAction?: Function) {
+    clearTimeout(debounceTimerRef.current);
+
+    debounceTimerRef.current = window.setTimeout(() => {
+      (innerAction || outerAction)?.();
+    }, delay);
+  }
+
+  return debounce;
+}

--- a/src/pages/api/peoples/sync.ts
+++ b/src/pages/api/peoples/sync.ts
@@ -10,7 +10,7 @@ export default async (
     return response.status(405).end();
   }
 
-  const { senderPeople, targetPeopleID, countdownStartedAt } = request.body;
+  const { senderPeople, targetPeopleID, showPoints } = request.body;
 
   const pusher = connectOnPusherServer();
 
@@ -18,7 +18,7 @@ export default async (
     people_id: senderPeople.id,
     selected_points: senderPeople.points,
     target_people_id: targetPeopleID,
-    room_countdown_started_at: countdownStartedAt,
+    show_points: showPoints,
   });
 
   return response.end();

--- a/src/pages/api/save-events.ts
+++ b/src/pages/api/save-events.ts
@@ -39,7 +39,7 @@ export default async (request: NextApiRequest, response: NextApiResponse) => {
     switch (parsedEventType) {
       case WebhookVaultEvent.room_show_points:
         await eventVault[parsedEventType]({
-          event_sended_at: new Date(parsedEventData.room_countdown_started_at),
+          event_sended_at: eventsSendedAt,
           people_id: event.user_id,
           room_id: parsedRoomID,
           show_points: parsedEventData.show_points,

--- a/src/services/room-events/index.ts
+++ b/src/services/room-events/index.ts
@@ -20,10 +20,9 @@ function onPeopleSelectPoint(
 
 function onRoomShowPoints(
   subscription: PresenceChannel,
-  { room_countdown_started_at, show_points }: OnRoomShowPointsProps
+  { show_points }: OnRoomShowPointsProps
 ) {
   subscription.trigger(ClientRoomEvents.ROOM_SHOW_POINTS, {
-    room_countdown_started_at,
     show_points,
   });
 }
@@ -43,7 +42,7 @@ async function onRoomSyncPeople(
     people_id,
     selected_points,
     target_people_id,
-    room_countdown_started_at,
+    show_points,
   }: OnRoomSyncPeopleProps
 ) {
   await pusherClient.sendToUser(
@@ -52,7 +51,7 @@ async function onRoomSyncPeople(
     {
       people_id,
       selected_points,
-      room_countdown_started_at,
+      show_points,
     }
   );
 }

--- a/src/services/room-events/types.ts
+++ b/src/services/room-events/types.ts
@@ -18,7 +18,6 @@ export interface OnPeopleSelectPointProps {
 
 export interface OnRoomShowPointsProps {
   show_points: boolean;
-  room_countdown_started_at: number;
 }
 
 export interface OnPeopleFireConfettiProps {
@@ -29,5 +28,5 @@ export interface OnRoomSyncPeopleProps {
   target_people_id: string;
   people_id: string;
   selected_points: number;
-  room_countdown_started_at?: number;
+  show_points?: boolean;
 }

--- a/src/stores/room-store/index.ts
+++ b/src/stores/room-store/index.ts
@@ -165,7 +165,6 @@ const roomStore: StateCreator<RoomStoreProps, [], [], RoomStoreProps> = (
 
   async function setRoomPointsVisibility(
     show?: boolean,
-    startedAt = getDateWithTimezone().getTime(),
     mode: EventMode = EventMode.PUBLIC
   ) {
     const { basicInfo } = get();
@@ -173,13 +172,11 @@ const roomStore: StateCreator<RoomStoreProps, [], [], RoomStoreProps> = (
     if (mode === EventMode.PUBLIC) {
       roomEvents.onRoomShowPoints(basicInfo.subscription, {
         show_points: show,
-        room_countdown_started_at: startedAt,
       });
     }
 
     roomHandler.onShowPoints({
       show_points: show,
-      room_countdown_started_at: startedAt,
     });
   }
 

--- a/src/stores/room-store/types.ts
+++ b/src/stores/room-store/types.ts
@@ -52,11 +52,7 @@ export interface RoomStoreProps {
   connectOnRoom(roomBasicInfo: BasicRoomInfo): Promise<() => void>;
   disconnectOnRoom(): void;
   selectPoint(points: number): Promise<void>;
-  setRoomPointsVisibility(
-    show?: boolean,
-    startedAt?: number,
-    mode?: EventMode
-  ): Promise<void>;
+  setRoomPointsVisibility(show?: boolean, mode?: EventMode): Promise<void>;
   broadcastConfetti(): void;
   setPeopleHighlight(people_id: string, highlight?: boolean): void;
 }

--- a/src/stores/room-store/types.ts
+++ b/src/stores/room-store/types.ts
@@ -41,7 +41,6 @@ export interface RoomStoreProps {
     name?: string;
     showPoints: boolean;
     showPointsCountdown?: number;
-    countdownStartedAt?: number;
     subscription?: PresenceChannel;
   };
   peoples: People[];
@@ -72,7 +71,6 @@ export interface OnLoadPeopleProps {
 export interface OnSyncPeopleProps {
   id: string;
   points: number;
-  countdownStartedAt?: number;
 }
 
 export interface OnHighlightPeopleProps {


### PR DESCRIPTION
### Motivação
Há um problema onde a contagem regressiva buga dependendo do dispositivo, por divergências significativas no timestamp dos dispositivos. Testei com meu celular e meu computador, e identifiquei uma diferença de 60 segundos.

### Solução
- Simplificação da contagem regressiva, removendo a dependência dos timestamps, tornando-o mais simples;
- O botão de nova partida fica desabilitado por 1 segundo após a contagem regressiva, para que ninguém consiga iniciar uma nova antes que todos já tenham passado pela contagem.