### PR TITLE
fix: add afk alert event to event type parsers object

### DIFF
--- a/src/pages/api/save-events.ts
+++ b/src/pages/api/save-events.ts
@@ -12,6 +12,7 @@ const eventTypeParsers = {
     WebhookVaultEvent.people_fire_confetti,
   [ClientRoomEvents.PEOPLE_SELECT_POINT]: WebhookVaultEvent.people_select_point,
   [ClientRoomEvents.ROOM_SHOW_POINTS]: WebhookVaultEvent.room_show_points,
+  [ClientRoomEvents.ROOM_SHOW_AFK_ALERT]: WebhookVaultEvent.room_show_afk_alert,
 };
 
 export default async (request: NextApiRequest, response: NextApiResponse) => {


### PR DESCRIPTION
### Motivação
O evento de quem apertou no botão de alertar quem ainda não votou não está sendo enviado para o Amplitude corretamente

### Solução
Adição do evento no objeto parser dos eventos