### PR TITLE
fix: apply new people name correctly

### DIFF
--- a/src/components/domain/connection-form/people-name.tsx
+++ b/src/components/domain/connection-form/people-name.tsx
@@ -28,7 +28,7 @@ export function PeopleName({ isLoading }: PeopleNameProps) {
     const newPeopleName = event.target.value;
 
     setPeopleName(newPeopleName);
-    applyPeopleName(onChangeCookie);
+    applyPeopleName(() => onChangeCookie(newPeopleName));
   }
 
   return (


### PR DESCRIPTION
### Motivação
Há um bug onde se alterar o nome muito rápido e logo entrar em uma sala, o nome é resetado completamente

### Solução
Uso correto da função de callback do debounce `applyPeopleName`